### PR TITLE
Added support for cancelling Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A very simple global message-passing library for dart/js interop, based on custom events.
 It's particularly useful as a two way communication system between dart and Js contexts.
 
-### Dart API
+## Dart API
 a `Service` receives all messages created by a following `transmit` with a matching `type`
 
 ```dart
@@ -73,7 +73,7 @@ void stopListening() {
 }
 ```
 
-### JS API
+## JS API
 
 ```javascript
 transmit(String type, content);

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ It's particularly useful as a two way communication system between dart and Js c
 ### Dart API
 a `Service` receives all messages created by a following `transmit` with a matching `type`
 
-    Service(List<String> types, Function target);
+```dart
+Service(List<String> types, Function target);
 
-    transmit(String type, var content);
+transmit(String type, var content);
+```
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -12,26 +12,67 @@ a `Service` receives all messages created by a following `transmit` with a match
 
 ### Example
 
-    main() {
-      new Service(['pokemon'], choose);
-      new Service(['attack'], waterGun);
+```dart
+main() {
+    new Service(['pokemon'], choose);
+    new Service(['attack'], waterGun);
 
-      // Messages trigger services that contain their types.
-      transmit('pokemon', 'Squirtle');
+    // Messages trigger services that contain their types.
+    transmit('pokemon', 'Squirtle');
         // => I choose you Squirtle!
-      transmit('attack', 'Squirtle');
+    transmit('attack', 'Squirtle');
         // => Squirtle used Water Gun!
-    }
+}
 
-    waterGun(content) {
-      print('${content} used Water Gun!');
-    }
+waterGun(content) {
+    print('${content} used Water Gun!');
+}
 
-    choose(content) {
-      print('I choose you ${content}!');
-    }
+choose(content) {
+    print('I choose you ${content}!');
+}
+```
+    
+### Cancelling a Service
+
+Cancel services any time you want it to stop running the callback. In order to cancel a Service, you'll need to store it in a Service variable.
+
+In this example, the service will run once, because it cancels itself.
+Notice that the Service variable is declared *before* it is defined, allowing the callback to access it.
+
+```dart
+main() {
+    Service myService;
+    myService = new Service(['rattata'], (_) {
+        // code here will only run on the first transmit(),
+        // because this line turns off the Service:
+        myService.cancel();
+    });
+}
+```
+    
+Cancel Services from anywhere the declared Service is accessible:
+
+```dart
+import "dart:html";
+
+Service myPublicService;
+    
+main() {
+    myPublicService = new Service(['trapinch'], (_) {
+        print("Trapinch never made it live");
+    });
+        
+    querySelector("#myButton").onClick.first.then((_) => stopListening());
+}
+    
+void stopListening() {
+    myPublicService.cancel();
+}
+```
 
 ### JS API
-    
-    transmit(String type, content);
-    
+
+```javascript
+transmit(String type, content);
+```

--- a/lib/transmit.dart
+++ b/lib/transmit.dart
@@ -16,13 +16,23 @@ JsFunction get jsTransmit => context['transmit'];
 
 /// A [Service] reacts to every message transmitted of type in [types]
 class Service {
-  Function callback;
+	Function callback;
+	bool enabled = false;
 
-  Service(final List channels, this.callback) {
-    for (var channel in channels) {
-      if (!(channel is String) && !(channel is int)) throw('channel must be a String or and int');
-      document.addEventListener('PUMP_' + channel.toString(),
-          (CustomEvent event) => callback(event.detail));
-    }
-  }
+	Service(final List channels, this.callback) {
+		for (var channel in channels) {
+			if (!(channel is String) && !(channel is int)) throw('channel must be a String or and int');
+			document.addEventListener('PUMP_' + channel.toString(),
+				(CustomEvent event) {
+				if (enabled) {
+					callback(event.detail);
+				}
+			});
+		}
+		enabled = true;
+	}
+
+	cancel() {
+		enabled = false;
+	}
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: transmit
-version: 1.1.0
+version: 1.1.5
 author: Paul VanKeuren <paul.vankeuren@gmail.com>
 description: A dart package that allows for quick event passing between distinct parts of your codebase.
 dev_dependencies:


### PR DESCRIPTION
Calling `.cancel()` on a `Service` will stop it from handling running the callback when a `transmit()` event is received.

Only merge if you want to, I just needed this for a side project and now I'm downloading it from my fork.
